### PR TITLE
Pageview hit type

### DIFF
--- a/lib/made_to_measure.rb
+++ b/lib/made_to_measure.rb
@@ -5,6 +5,7 @@ require "made_to_measure/config"
 require "made_to_measure/interaction"
 require "made_to_measure/ecommerce/transaction"
 require "made_to_measure/ecommerce/item"
+require "made_to_measure/pageview"
 
 module MadeToMeasure
   module Ecommerce

--- a/lib/made_to_measure/pageview.rb
+++ b/lib/made_to_measure/pageview.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module MadeToMeasure
+  class Pageview < MadeToMeasure::Interaction
+    def initialize(page:, title: nil, document_hostname: nil, client_id: nil)
+      @page = page
+      @title = title
+      @document_hostname = document_hostname
+      @client_id = client_id
+    end
+
+    def to_h
+      super.merge(dp: @page, dt: @title, dh: @document_hostname)
+    end
+  end
+end

--- a/spec/pageview_spec.rb
+++ b/spec/pageview_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe MadeToMeasure::Pageview do
+  let(:pageview) do
+    MadeToMeasure::Pageview.new(
+      page: '/test', title: 'test', document_hostname: 'mytest.com', client_id: '111'
+    )
+  end
+
+  before do
+    MadeToMeasure.config do |c|
+      c.version = 1
+      c.property_id = 'UA-12345-6'
+    end
+  end
+
+  describe 'commit' do
+    before do
+      @request = stub_request(:post, 'https://www.google-analytics.com/collect?cid=111&dh=mytest.com&dp=/test&dt=test&t=pageview&tid=UA-12345-6&v=1')
+                 .with(headers: { 'User-Agent': 'MadeToMeasure/0.2.2 (+https://github.com/dmgarland/made-to-measure)' })
+                 .to_return(status: 200, body: '', headers: {})
+      pageview.commit
+    end
+
+    it 'should send a page tracker request to google' do
+      expect(@request).to have_been_requested
+    end
+  end
+
+  describe '#to_h' do
+    it 'should return a hash of query parameters' do
+      expect(pageview.to_h).to eq(
+        {
+          v:   1,
+          tid: 'UA-12345-6',
+          t:   'pageview',
+          cid: '111',
+          dp:  '/test',
+          dt:  'test',
+          dh:  'mytest.com'
+        }
+      )
+    end
+  end
+end

--- a/spec/pageview_spec.rb
+++ b/spec/pageview_spec.rb
@@ -3,10 +3,9 @@
 require 'spec_helper'
 
 RSpec.describe MadeToMeasure::Pageview do
-  let(:pageview) do
-    MadeToMeasure::Pageview.new(
-      page: '/test', title: 'test', document_hostname: 'mytest.com', client_id: '111'
-    )
+  let(:pageview) { MadeToMeasure::Pageview.new(*pageview_params) }
+  let(:pageview_params) do
+    [page: '/test', title: 'test', document_hostname: 'mytest.com', client_id: '111']
   end
 
   before do
@@ -21,11 +20,22 @@ RSpec.describe MadeToMeasure::Pageview do
       @request = stub_request(:post, 'https://www.google-analytics.com/collect?cid=111&dh=mytest.com&dp=/test&dt=test&t=pageview&tid=UA-12345-6&v=1')
                  .with(headers: { 'User-Agent': 'MadeToMeasure/0.2.2 (+https://github.com/dmgarland/made-to-measure)' })
                  .to_return(status: 200, body: '', headers: {})
-      pageview.commit
     end
 
-    it 'should send a page tracker request to google' do
-      expect(@request).to have_been_requested
+    context 'including all required parameters' do
+      before { pageview.commit }
+
+      it 'should send a page tracker request to google' do
+        expect(@request).to have_been_requested
+      end
+    end
+
+    context 'missing required parameters' do
+      let(:pageview_params) { [title: 'test', document_hostname: 'mytest.com', client_id: '111'] }
+
+      it 'should raise an argument' do
+        expect { pageview.commit }.to raise_error(ArgumentError).with_message('missing keyword: page')
+      end
     end
   end
 


### PR DESCRIPTION
Added the pageview hit type.

How?
- Created the pageview class, which inherits from MadeToMeasuer::Interaction.
- Overrode #to_h so we can add the extra parameters into the header.